### PR TITLE
resolve aclocal and compile warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -812,19 +812,20 @@ AC_ARG_WITH(valgrind,
     save_cppflags="$CPPFLAGS"
     AC_MSG_CHECKING(for valgrind.h usability)
     if test "x$withval" = xyes ; then
-	AC_COMPILE_IFELSE([#include <valgrind.h>], found=yes)
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <valgrind.h>]])],
+                          found=yes)
 	if test x$found = xno ; then
 	    CPPFLAGS="$CPPFLAGS -I/usr/include/valgrind"
-	    AC_COMPILE_IFELSE([#include <valgrind.h>], found=yes,
-		CPPFLAGS="$save_cppflags")
+	    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <valgrind.h>]])],
+                              found=yes, CPPFLAGS="$save_cppflags")
 	fi
     else
 	for d in $withval $withval/include \
 	         $withval/valgrind $withval/include/valgrind
 	do
 	    CPPFLAGS="$CPPFLAGS -I$d"
-	    AC_COMPILE_IFELSE([#include <valgrind.h>], found=yes,
-		CPPFLAGS="$save_cppflags")
+	    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#include <valgrind.h>]])],
+                found=yes, CPPFLAGS="$save_cppflags")
 	    if test x$found = xyes ; then
 		break
 	    fi

--- a/include/pvfs2-types.h
+++ b/include/pvfs2-types.h
@@ -73,9 +73,9 @@ typedef int64_t PVFS_id_gen_t;
 /** Opaque value representing a destination address. */
 typedef int64_t PVFS_BMI_addr_t;
 
-inline void encode_PVFS_BMI_addr_t(char **pptr, const PVFS_BMI_addr_t *x);
-inline int encode_PVFS_BMI_addr_t_size_check(const PVFS_BMI_addr_t *x);
-inline void decode_PVFS_BMI_addr_t(char **pptr, PVFS_BMI_addr_t *x);
+void encode_PVFS_BMI_addr_t(char **pptr, const PVFS_BMI_addr_t *x);
+int encode_PVFS_BMI_addr_t_size_check(const PVFS_BMI_addr_t *x);
+void decode_PVFS_BMI_addr_t(char **pptr, PVFS_BMI_addr_t *x);
 
 #define encode_PVFS_error encode_int32_t
 #define decode_PVFS_error decode_int32_t
@@ -226,8 +226,8 @@ typedef struct PVFS_sys_layout_s
 } PVFS_sys_layout;
 #define extra_size_PVFS_sys_layout PVFS_REQ_LIMIT_LAYOUT
 
-inline void encode_PVFS_sys_layout(char **pptr, const struct PVFS_sys_layout_s *x);
-inline void decode_PVFS_sys_layout(char **pptr, struct PVFS_sys_layout_s *x);
+void encode_PVFS_sys_layout(char **pptr, const struct PVFS_sys_layout_s *x);
+void decode_PVFS_sys_layout(char **pptr, struct PVFS_sys_layout_s *x);
 
 /* predefined special values for types */
 #define PVFS_CONTEXT_NULL    ((PVFS_context_id)-1)

--- a/maint/config/aio.m4
+++ b/maint/config/aio.m4
@@ -15,7 +15,7 @@ AC_DEFUN([AX_AIO],
         LIBS="$LIBS -laio"
     
         AC_COMPILE_IFELSE(
-    	    [#include "libaio.h"],
+    	    [AC_LANG_SOURCE([[#include "libaio.h"]])],
     	    [],
     	    [AC_MSG_ERROR(Invalid libaio path specified.  No libaio.h found.)])
     
@@ -38,7 +38,7 @@ AC_DEFUN([AX_AIO_OPTIONAL],
     LIBS="$LIBS -laio"
 
     AC_COMPILE_IFELSE(
-      [#include "libaio.h"],
+      [AC_LANG_SOURCE([[#include "libaio.h"]])],
       [],
       [AC_MSG_WARN(No libaio headers found.)])
 

--- a/maint/config/bdb.m4
+++ b/maint/config/bdb.m4
@@ -17,14 +17,18 @@ AC_DEFUN([AX_BERKELEY_DB],
 	oldcflags=$CFLAGS
 	for dbheader in db4 db3 notfound; do
 		AC_COMPILE_IFELSE(
-			[#include "$dbpath/include/$dbheader/db.h"],
+			[AC_LANG_SOURCE(
+				[[#include "$dbpath/include/$dbheader/db.h"]])
+			],
 			[DB_CFLAGS="-I$dbpath/include/$dbheader/"
 			 break])
 	done
 
 	if test "x$dbheader" = "xnotfound"; then
 		AC_COMPILE_IFELSE(
-			[#include "$dbpath/include/db.h"],
+			[AC_LANG_SOURCE(
+				[[#include "$dbpath/include/db.h"]])
+			],
 			[DB_CFLAGS="-I$dbpath/include/"],
 			[AC_MSG_FAILURE(
 				Invalid libdb path specified. No db.h found.)])

--- a/maint/config/openssl.m4
+++ b/maint/config/openssl.m4
@@ -15,7 +15,9 @@ AC_DEFUN([AX_OPENSSL],
         LIBS="$LIBS -lcrypto -lssl"
     
         AC_COMPILE_IFELSE(
-    	    [#include "openssl/bio.h"],
+    	    [AC_LANG_SOURCE(
+		[[#include "openssl/bio.h"]])
+	    ],
     	    [],
     	    [AC_MSG_ERROR(Invalid openssl path specified.  No openssl/bio.h found.)])
     
@@ -39,7 +41,9 @@ AC_DEFUN([AX_OPENSSL_OPTIONAL],
     LIBS="$LIBS -lcrypto -lssl"
 
     AC_COMPILE_IFELSE(
-      [#include "openssl/bio.h"],
+      [AC_LANG_SOURCE(
+        [[#include "openssl/bio.h"]])
+      ],
       [],
       [AC_MSG_WARN(No openssl headers found.)])
 

--- a/pvfs2-config.h.in
+++ b/pvfs2-config.h.in
@@ -1,4 +1,4 @@
-/* pvfs2-config.h.in.  Generated from configure.in by autoheader.  */
+/* pvfs2-config.h.in.  Generated from configure.ac by autoheader.  */
 
 /* Define if building universal (internal helper macro) */
 #undef AC_APPLE_UNIVERSAL_BUILD

--- a/src/common/misc/str-utils.c
+++ b/src/common/misc/str-utils.c
@@ -279,7 +279,7 @@ int PINT_get_path_element(
     int count = -1;
     char *segp = (char *)0;
     void *segstate = NULL;
-    char local_pathname[PVFS_NAME_MAX] = {0};
+    char local_pathname[PVFS_NAME_MAX+1] = {0};
 
     strncpy(local_pathname,pathname,PVFS_NAME_MAX);
 


### PR DESCRIPTION
for aclocal:
 - rename configure.in to configure.ac as suggested by warning
 - encapsulate source code in AC_COMPILE_IFELSE statements with AC_LANG_SOURCE as suggested by warning
 
for compiler warnings:
 - remove 'inline' qualifier from prototypes in pvfs2-types.h to avoid 'inline function declared but never defined' warning for decode_PVFS_sys_layout(), encode_PVFS_sys_layout(), decode_PVFS_BMI_addr_t(), encode_PVFS_BMI_addr_t_size_check(), and encode_PVFS_BMI_addr_t().
 - increase size of tmp buffer in PINT_get_path_element() to avoid "'__builtin_strncpy' specified bound 256 equals destination size" warning